### PR TITLE
Add description of wasm-bindgen feature

### DIFF
--- a/website/docs/user_guides/rust/getting_started.mdx
+++ b/website/docs/user_guides/rust/getting_started.mdx
@@ -33,6 +33,7 @@ Has a great cross-platform support but requires a nightly version of the Rust co
 - `serde-serialize`: enables serialization of the physics components with [`serde`](https://github.com/serde-rs/serde).
 - `enhanced-determinism`: enables cross-platform determinism across all 32-bit and 64-bit platforms that implements the
 IEEE 754-2008 standard strictly. This includes most modern processors as well as WASM targets.
+- `wasm-bindgen`: enables usage of `rapier` as a dependency of a WASM crate that is compiled with `wasm-bindgen`.
 
 Currently, the `enhanced-determinism` feature cannot be enabled at the same time as the `parallel` or
 `simd-{stable,nightly}` features.


### PR DESCRIPTION
`rapier` depends on the `instant` crate which won't compile for WASM unless the appropriate feature flags are turned on. This can be done through using `rapier`'s `wasm-bindgen` feature. I added a mention of this feature on the Getting started part of the user guide so people won't have to dig around for this information since the error messages from the browser (these happen at ES6 module linking) aren't very helpful.