### PR TITLE
Fix error in the Javascript 2D example

### DIFF
--- a/website/docs/user_guides/templates/getting_started_js.mdx
+++ b/website/docs/user_guides/templates/getting_started_js.mdx
@@ -76,7 +76,7 @@ import('@dimforge/rapier2d').then(RAPIER => {
 
       // Get and print the rigid-body's position.
       let position = rigidBody.translation();
-      console.log("Rigid-body position: ", position.x, position.y, position.z);
+      console.log("Rigid-body position: ", position.x, position.y);
 
       setTimeout(gameLoop, 16);
     };


### PR DESCRIPTION
The example code for Rapier2D in the JS section cannot work.

This line:
```js
console.log("Rigid-body position: ", position.x, position.y, position.z);
```

Has to be changed to:
```js
console.log("Rigid-body position: ", position.x, position.y);
```
Because `position.z` does not exist in the 2D coordinates system.