### PR TITLE
Fix Bevy code samples in scene queries chapter

### DIFF
--- a/docs/user_guides/templates/scene_queries_intersection_test.mdx
+++ b/docs/user_guides/templates/scene_queries_intersection_test.mdx
@@ -100,7 +100,7 @@ fn test_intersections(rapier_context: Res<RapierContext>) {
     });
 
     let aabb = Aabb::from_min_max(Vec3::new(-1.0, -2.0, 0.0), Vec3::new(1.0, 2.0, 0.0));
-    query_pipeline.colliders_with_aabb_intersecting_aabb(&aabb, |entity| {
+    rapier_context.colliders_with_aabb_intersecting_aabb(&aabb, |entity| {
         println!("The entity {:?} has an AABB intersecting our test AABB", entity);
         true // Return `false` instead if we want to stop searching for other colliders that contain this point.
     });
@@ -126,7 +126,7 @@ fn test_intersections(rapier_context: Res<RapierContext>) {
     });
 
     let aabb = Aabb::from_min_max(Vec3::new(-1.0, -2.0, -3.0), Vec3::new(1.0, 2.0, 3.0));
-    query_pipeline.colliders_with_aabb_intersecting_aabb(&aabb, |entity| {
+    rapier_context.colliders_with_aabb_intersecting_aabb(&aabb, |entity| {
         println!("The entity {:?} has an AABB intersecting our test AABB", entity);
         true // Return `false` instead if we want to stop searching for other colliders that contain this point.
     });

--- a/docs/user_guides/templates/scene_queries_ray_casting.mdx
+++ b/docs/user_guides/templates/scene_queries_ray_casting.mdx
@@ -134,7 +134,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
     let groups = InteractionGroups::all();
     let filter = None;
 
-    if let Some((entity, toi)) = query_pipeline.cast_ray(
+    if let Some((entity, toi)) = rapier_context.cast_ray(
         ray_pos, ray_dir, max_toi, solid, groups, filter
     ) {
         // The first collider hit has the entity `entity` and it hit after
@@ -144,7 +144,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
     }
 
 
-    if let Some((entity, intersection)) = query_pipeline.cast_ray_and_get_normal(
+    if let Some((entity, intersection)) = rapier_context.cast_ray_and_get_normal(
         ray_pos, ray_dir, max_toi, solid, groups, filter
     ) {
         // This is similar to `QueryPipeline::cast_ray` illustrated above except
@@ -154,7 +154,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
         println!("Entity {:?} hit at point {} with normal {}", entity, hit_point, hit_normal);
     }
 
-    query_pipeline.intersections_with_ray(
+    rapier_context.intersections_with_ray(
         ray_pos, ray_dir, max_toi, solid, groups, filter,
         |entity, intersection| {
             // Callback called on each collider hit by the ray.
@@ -180,7 +180,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
     let groups = InteractionGroups::all();
     let filter = None;
 
-    if let Some((entity, toi)) = query_pipeline.cast_ray(
+    if let Some((entity, toi)) = rapier_context.cast_ray(
         ray_pos, ray_dir, max_toi, solid, groups, filter
     ) {
         // The first collider hit has the entity `entity` and it hit after
@@ -190,7 +190,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
     }
 
 
-    if let Some((entity, intersection)) = query_pipeline.cast_ray_and_get_normal(
+    if let Some((entity, intersection)) = rapier_context.cast_ray_and_get_normal(
         ray_pos, ray_dir, max_toi, solid, groups, filter
     ) {
         // This is similar to `QueryPipeline::cast_ray` illustrated above except
@@ -200,7 +200,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
         println!("Entity {:?} hit at point {} with normal {}", entity, hit_point, hit_normal);
     }
 
-    query_pipeline.intersections_with_ray(
+    rapier_context.intersections_with_ray(
         ray_pos, ray_dir, max_toi, solid, groups, filter,
         |entity, intersection| {
             // Callback called on each collider hit by the ray.

--- a/docs/user_guides/templates/scene_queries_shape_casting.mdx
+++ b/docs/user_guides/templates/scene_queries_shape_casting.mdx
@@ -115,7 +115,7 @@ fn cast_shape(rapier_context: Res<RapierContext>) {
     let groups = InteractionGroups::all();
     let filter = None;
 
-    if let Some((entity, hit)) = query_pipeline.cast_shape(
+    if let Some((entity, hit)) = rapier_context.cast_shape(
         shape_pos, shape_rot, shape_vel, &shape, max_toi, groups, filter
     ) {
         // The first collider hit has the entity `entity`. The `hit` is a


### PR DESCRIPTION
Fix Bevy code samples in scene queries chapter using undefined `query_pipeline` variable instead of `rapier_context`.
Looks like a copy-pasta error to me. Methods from `rapier_context.query_pipeline` use different parameters than ones used in samples so I guessed that methods from `rapier_context` were intended.