### PR TITLE
Update bevy_rapier documentation

### DIFF
--- a/docs/user_guides/templates/getting_started_bevy.mdx
+++ b/docs/user_guides/templates/getting_started_bevy.mdx
@@ -129,7 +129,7 @@ fn main() {
 
 fn setup_graphics(mut commands: Commands) {
     // Add a camera so we can see the debug-render.
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 }
 
 fn setup_physics(mut commands: Commands) {
@@ -175,7 +175,7 @@ fn main() {
 
 fn setup_graphics(mut commands: Commands) {
     // Add a camera so we can see the debug-render.
-    commands.spawn_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(-3.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
     });


### PR DESCRIPTION
- update the documentation of bevy_rapier to use bevy v0.8 methods according to [migaration guides on camera](https://bevyengine.org/learn/book/migration-guides/0.7-0.8/#camera-driven-rendering).