### PR TITLE
Fix Typos for bevy 2d examples in Scene Queries docs

### DIFF
--- a/docs/user_guides/templates/scene_queries_ray_casting.mdx
+++ b/docs/user_guides/templates/scene_queries_ray_casting.mdx
@@ -144,7 +144,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
     if let Some((entity, intersection)) = rapier_context.cast_ray_and_get_normal(
         ray_pos, ray_dir, max_toi, solid, filter
     ) {
-        // This is similar to `QueryPipeline::cast_ray` illustrated above except
+        // This is similar to `RapierContext::cast_ray` illustrated above except
         // that it also returns the normal of the collider shape at the hit point.
         let hit_point = intersection.point;
         let hit_normal = intersection.normal;

--- a/docs/user_guides/templates/scene_queries_shape_casting.mdx
+++ b/docs/user_guides/templates/scene_queries_shape_casting.mdx
@@ -88,7 +88,7 @@ fn cast_shape(rapier_context: Res<RapierContext>) {
     let max_toi = 4.0;
     let filter = QueryFilter::default();
 
-    if let Some((entity, hit)) = query_pipeline.cast_shape(
+    if let Some((entity, hit)) = rapier_context.cast_shape(
         shape_pos, shape_rot, shape_vel, &shape, max_toi, filter
     ) {
         // The first collider hit has the entity `entity`. The `hit` is a


### PR DESCRIPTION
These incorrectly reference the name for standalone rapier in the bevy 2d examples.