### PR TITLE
Fix invalid creation of Sensor type

### DIFF
--- a/docs/user_guides/templates/collider_type.mdx
+++ b/docs/user_guides/templates/collider_type.mdx
@@ -34,7 +34,7 @@ assert!(collider.is_sensor());
 /* Set the collider sensor when the collider is created. */
 commands.spawn()
     .insert(Collider::ball(0.5))
-    .insert(Sensor(true));
+    .insert(Sensor);
 ```
 ```rust
 /* Change the collider sensor status inside of a system. */


### PR DESCRIPTION
This fixes a small typo when creating a `Sensor` (it's a [unit struct](https://docs.rs/bevy_rapier2d/latest/bevy_rapier2d/geometry/struct.Sensor.html)).

As always, thanks a lot for this work!