### PR TITLE
update joint limits and sensor examples

### DIFF
--- a/docs/user_guides/templates/collider_creation_and_insertion.mdx
+++ b/docs/user_guides/templates/collider_creation_and_insertion.mdx
@@ -156,7 +156,7 @@ use bevy_rapier2d::prelude::*;
 
 commands.spawn()
     .insert(Collider::cuboid(1.0, 2.0))
-    .insert(Sensor(true))
+    .insert(Sensor)
     .insert_bundle(TransformBundle::from(Transform::from_xyz(2.0, 0.0, 0.0)))
     .insert(Friction::coefficient(0.7))
     .insert(Restitution::coefficient(0.3))
@@ -171,7 +171,7 @@ use bevy_rapier3d::prelude::*;
 
 commands.spawn()
     .insert(Collider::cuboid(1.0, 2.0, 3.0))
-    .insert(Sensor(true))
+    .insert(Sensor)
     .insert_bundle(TransformBundle::from(Transform::from_xyz(2.0, 0.0, 0.0)))
     .insert(Friction::coefficient(0.7))
     .insert(Restitution::coefficient(0.3))

--- a/docs/user_guides/templates/joints.mdx
+++ b/docs/user_guides/templates/joints.mdx
@@ -327,7 +327,7 @@ let x = Vector::x_axis();
 let mut joint = PrismaticJointBuilder::new(x)
     .local_anchor1(point![0.0, 1.0])
     .local_anchor2(point![0.0, -3.0])
-    .limit_axis([-2.0, 5.0]);
+    .limits([-2.0, 5.0]);
 joint_set.insert(&mut rigid_body_set, body_handle1, body_handle2, joint, true);
 ```
 
@@ -339,7 +339,7 @@ let x = Vector::x_axis();
 let mut joint = PrismaticJointBuilder::new(x)
     .local_anchor1(point![0.0, 0.0, 1.0])
     .local_anchor2(point![0.0, 0.0, -3.0])
-    .limit_axis([-2.0, 5.0]);
+    .limits([-2.0, 5.0]);
 joint_set.insert(&mut rigid_body_set, body_handle1, body_handle2, joint, true);
 ```
 
@@ -362,7 +362,7 @@ values={[
 let mut joint = PrismaticJointBuilder::new(Vec2::X)
     .local_anchor1(Vec2::new(0.0, 1.0))
     .local_anchor2(Vec2::new(0.0, -3.0))
-    .limit_axis([-2.0, 5.0]);
+    .limits([-2.0, 5.0]);
 commands.spawn()
     .insert(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
@@ -375,7 +375,7 @@ commands.spawn()
 let mut joint = PrismaticJointBuilder::new(Vec3::X)
     .local_anchor1(Vec3::new(0.0, 0.0, 1.0))
     .local_anchor2(Vec3::new(0.0, 0.0, -3.0))
-    .limit_axis([-2.0, 5.0]);
+    .limits([-2.0, 5.0]);
 commands.spawn()
     .insert(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);


### PR DESCRIPTION
Fixes a couple examples in documentation using outdated `.insert(Sensor(true))` and `PrismaticJointBuilder::limit_axis` syntax.