### PR TITLE
References debug-render-2d and debug-render-3d

### DIFF
--- a/docs/user_guides/templates/advanced_collision_detection.mdx
+++ b/docs/user_guides/templates/advanced_collision_detection.mdx
@@ -389,12 +389,12 @@ Sometimes, [collision groups and solver groups](colliders#collision-groups-and-s
 to achieve the desired behavior. In that case, the contact filtering hooks let you apply custom rules to filter contact
 pairs and intersection pairs:
 - For each potential contact pair (between two non-sensor colliders) detected by the broad-phase, if at least one
-  of the colliders involved in the pair has the bit `ActiveHooks::FILTER_CONTACT_PAIRS` enabled in its
+  of the colliders involved in the pair has the bit `ActiveHooks::FILTER_CONTACT_PAIR` enabled in its
   [active hooks](colliders#active-hooks), then `PhysicsHooks::filter_contact_pair` will be called. If this filter
   returns `None` then no contact computation will happen for this pair of colliders. If it returns `Some` then the
   narrow-phase will compute contact points.
 - For each potential intersection pair (between a sensor colliders and another collider) detected by the broad-phase, if
-  at least one of the colliders involved in the pair has the bit `ActiveHooks::FILTER_INTERSECTION_PAIRS` enabled
+  at least one of the colliders involved in the pair has the bit `ActiveHooks::FILTER_INTERSECTION_PAIR` enabled
   in its [active hooks](colliders#active-hooks), then `PhysicsHooks::filter_intersection_pair` will be called. If this
   filter returns `false` then no intersection computation will happen for this pair of colliders. If it returns `true`
   then the narrow-phase will test whether or not they are intersecting.
@@ -505,15 +505,9 @@ fn setup_physics(mut commands: Commands) {
     // Add colliders with a `CustomFilterTag` component. Only colliders
     // with the same `CustomFilterTag` variant will collider thanks to
     // our custom physics hooks:
-    let collider = ColliderBundle {
-        material: ColliderMaterial {
-            active_hooks: ActiveHooks::FILTER_CONTACT_PAIRS 
-                | ActiveHooks::FILTER_INTERSECTION_PAIRS,
-            ..Default::default()
-        }.into(),
-        ..Default::default()
-    };
-    commands.spawn_bundle(collider)
+    commands.spawn(Collider::Ball(0.5))
+        .insert(ActiveHooks::FILTER_CONTACT_PAIR
+            | ActiveHooks::FILTER_INTERSECTION_PAIR)
         .insert(CustomFilterTag::GroupA);
     
     // TODO: add other colliders in a similar way.

--- a/docs/user_guides/templates/advanced_collision_detection.mdx
+++ b/docs/user_guides/templates/advanced_collision_detection.mdx
@@ -638,8 +638,7 @@ fn setup_physics(mut commands: Commands) {
     // Add colliders with a `CustomFilterTag` component. Only colliders
     // with the same `CustomFilterTag` variant will collider thanks to
     // our custom physics hooks:
-    commands.spawn()
-        .insert(Collider::ball(0.5))
+    commands.spawn(Collider::ball(0.5))
         .insert(ActiveHooks::MODIFY_SOLVER_CONTACTS);
 
     // TODO: add other colliders in a similar way.

--- a/docs/user_guides/templates/advanced_collision_detection_js.mdx
+++ b/docs/user_guides/templates/advanced_collision_detection_js.mdx
@@ -123,7 +123,7 @@ pairs and intersection pairs:
   returns `null` then no contact computation will happen for this pair of colliders. If it returns a `SolverFlags` value then the
   narrow-phase will compute contact points.
 - For each potential intersection pair (between a sensor colliders and another collider) detected by the broad-phase, if
-  at least one of the colliders involved in the pair has the bit `ActiveHooks.FILTER_INTERSECTION_PAIRS` enabled
+  at least one of the colliders involved in the pair has the bit `ActiveHooks.FILTER_INTERSECTION_PAIR` enabled
   in its [active hooks](colliders#active-hooks), then `PhysicsHooks.filterIntersectionPair` will be called. If this
   filter returns `false` then no intersection computation will happen for this pair of colliders. If it returns `true`
   then the narrow-phase will test whether or not they are intersecting.

--- a/docs/user_guides/templates/character_controller_collisions.mdx
+++ b/docs/user_guides/templates/character_controller_collisions.mdx
@@ -107,8 +107,7 @@ character_controller.solve_character_collision_impulses(
 
 ```rust
 /* Configure the character controller when the collider is created. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         // Enable the automatic application of impulses to the dynamic bodies
         // hit by the character along its path.

--- a/docs/user_guides/templates/character_controller_offset.mdx
+++ b/docs/user_guides/templates/character_controller_offset.mdx
@@ -22,16 +22,14 @@ character_controller.offset = CharacterLength::Relative(0.01);
 
 ```rust
 /* Configure the character controller when the collider is created. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         // The character offset is set to 0.01.
         offset: CharacterLength::Absolute(0.01),
         ..default()
     });
 
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         // The character offset is set to 0.01 multiplied by the collider’s height.
         offset: CharacterLength::Absolute(0.01),

--- a/docs/user_guides/templates/character_controller_setup.mdx
+++ b/docs/user_guides/templates/character_controller_setup.mdx
@@ -116,8 +116,7 @@ values={[
 
 ```rust
 fn init_system(mut commands: Commands) {
-    commands.spawn()
-        .insert(RigidBody::KinematicPositionBased)
+    commands.spawn(RigidBody::KinematicPositionBased)
         .insert(Collider::ball(0.5))
         .insert(KinematicCharacterController::default());
 }
@@ -141,8 +140,7 @@ fn read_result_system(controllers: Query<Entity, &KinematicCharacterControllerOu
 
 ```rust
 fn init_system(mut commands: Commands) {
-    commands.spawn()
-        .insert(RigidBody::KinematicPositionBased)
+    commands.spawn(RigidBody::KinematicPositionBased)
         .insert(Collider::ball(0.5))
         .insert(KinematicCharacterController::default());
 }

--- a/docs/user_guides/templates/character_controller_slopes.mdx
+++ b/docs/user_guides/templates/character_controller_slopes.mdx
@@ -28,8 +28,7 @@ character_controller.min_slope_slide_angle = 30.0.to_radians();
 ```rust
 /* Configure the character controller when the collider is created. */
 // Snap to the ground if the vertical distance to the ground is smaller than 0.5.
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         // Don’t allow climbing slopes larger than 45 degrees.
         max_slope_climb_angle: 45.0.to_radians(),

--- a/docs/user_guides/templates/character_controller_snap_to_ground.mdx
+++ b/docs/user_guides/templates/character_controller_snap_to_ground.mdx
@@ -30,16 +30,14 @@ character_controller.snap_to_ground = Some(CharacterLength::Relative(0.2));
 ```rust
 /* Configure the character controller when the collider is created. */
 // Snap to the ground if the vertical distance to the ground is smaller than 0.5.
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         snap_to_ground: Some(CharacterLength::Absolute(0.5)),
         ..default()
     });
 
 // Snap to the ground if the vertical distance to the ground is smaller than 0.2 times the character’s height
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         snap_to_ground: Some(CharacterLength::Relative(0.2)),
         ..default()

--- a/docs/user_guides/templates/character_controller_stairs.mdx
+++ b/docs/user_guides/templates/character_controller_stairs.mdx
@@ -50,8 +50,7 @@ character_controller.autostep = Some(CharacterAutostep {
 ```rust
 /* Configure the character controller when the collider is created. */
 // Autostep if the step height is smaller than 0.5, and its width larger than 0.2.
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         autostep: Some(CharacterAutostep {
             max_height: CharacterLength::Absolute(0.5),
@@ -64,8 +63,7 @@ commands.spawn()
 // Autostep if the step height is smaller than 0.5 multiplied by the character’s height,
 // and its width larger than 0.5 multiplied by the character’s width (i.e. half the character’s
 // width).
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         autostep: Some(CharacterAutostep {
             max_height: CharacterLength::Relative(0.3),

--- a/docs/user_guides/templates/character_controller_up_vector.mdx
+++ b/docs/user_guides/templates/character_controller_up_vector.mdx
@@ -30,8 +30,7 @@ values={[
 
 ```rust
 /* Character controller with the positive X axis as the up vector. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         up: Vec2::X,
         ..default()
@@ -51,8 +50,7 @@ fn modify_character_controller_autostep(mut character_controller: Query<&mut Kin
 
 ```rust
 /* Character controller with the positive Z axis as the up vector. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(KinematicCharacterController {
         up: Vec3::Z,
         ..default()

--- a/docs/user_guides/templates/collider_active_collision_types.mdx
+++ b/docs/user_guides/templates/collider_active_collision_types.mdx
@@ -29,8 +29,7 @@ assert!(collider.active_collision_types().contains(ActiveCollisionTypes::KINEMAT
 
 ```rust
 /* Set the active collision types when the collider is created. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(ActiveCollisionTypes::default() | ActiveCollisionTypes::KINEMATIC_FIXED);
 ```
 ```rust

--- a/docs/user_guides/templates/collider_active_events.mdx
+++ b/docs/user_guides/templates/collider_active_events.mdx
@@ -37,8 +37,7 @@ let collider = ColliderBundle {
     ..Default::default()
 };
 commands.spawn_bundle(collider);
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(ActiveEvents::COLLISION_EVENTS);
 ```
 ```rust

--- a/docs/user_guides/templates/collider_active_events.mdx
+++ b/docs/user_guides/templates/collider_active_events.mdx
@@ -32,11 +32,6 @@ assert!(collider.active_events().contains(ActiveEvents::COLLISION_EVENTS));
 
 ```rust
 /* Set the active events when the collider is created. */
-let collider = ColliderBundle {
-    flags: (ActiveEvents::COLLISION_EVENTS).into(),
-    ..Default::default()
-};
-commands.spawn_bundle(collider);
 commands.spawn(Collider::ball(0.5))
     .insert(ActiveEvents::COLLISION_EVENTS);
 ```

--- a/docs/user_guides/templates/collider_active_hooks.mdx
+++ b/docs/user_guides/templates/collider_active_hooks.mdx
@@ -41,8 +41,7 @@ assert!(collider.active_hooks().contains(ActiveHooks::MODIFY_SOLVER_CONTACTS));
 
 ```rust
 /* Set the active hooks when the collider is created. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(ActiveHooks::FILTER_CONTACT_PAIRS | ActiveHooks::MODIFY_SOLVER_CONTACTS);
 ```
 ```rust

--- a/docs/user_guides/templates/collider_active_hooks.mdx
+++ b/docs/user_guides/templates/collider_active_hooks.mdx
@@ -6,10 +6,10 @@ import TabItem from '@theme/TabItem';
 pairs, or modify contacts, based on arbitrary user code. In order to enable a physics hook for a pair of colliders, at
 least one of the involved colliders must have the corresponding hook set as active. A hook is activated for a collider
 by setting its corresponding active hooks bit to `1`:
-- Setting the <notjs>`ActiveHooks::FILTER_CONTACT_PAIRS`</notjs><js>`ActiveHooks.FILTER_CONTACT_PAIRS`</js> bit to 1
+- Setting the <notjs>`ActiveHooks::FILTER_CONTACT_PAIR`</notjs><js>`ActiveHooks.FILTER_CONTACT_PAIR`</js> bit to 1
   enables the manual [filtering of all the contact pairs](advanced_collision_detection#contact-and-intersection-filtering)
   involving the collider.
-- Setting the <notjs>`ActiveHooks::FILTER_INTERSECTION_PAIRS`</notjs><js>`ActiveHooks.FILTER_INTERSECTION_PAIRS`</js>bit
+- Setting the <notjs>`ActiveHooks::FILTER_INTERSECTION_PAIR`</notjs><js>`ActiveHooks.FILTER_INTERSECTION_PAIR`</js>bit
   to 1 enables the manual [filtering of all the contact pairs](advanced_collision_detection#contact-and-intersection-filtering)
   involving the collider.
 <notjs>- Setting the `ActiveHooks::MODIFY_SOLVER_CONTACTS` bit to 1

--- a/docs/user_guides/templates/collider_collision_groups.mdx
+++ b/docs/user_guides/templates/collider_collision_groups.mdx
@@ -64,7 +64,7 @@ assert_eq!(collider.solver_groups(), InteractionGroups::new(0b0011.into(), 0b101
 
 ```rust
 /* Set the collision and/or solver groups when the collider is created. */
-commands.spawn()
+commands.spawn(Collider::ball(0.5))
     .insert(CollisionGroups::new(0b1101.into(), 0b0100.into())
     .insert(SolverGroups::new(0b0011.into(), 0b1011.into());
 ```

--- a/docs/user_guides/templates/collider_creation_and_insertion.mdx
+++ b/docs/user_guides/templates/collider_creation_and_insertion.mdx
@@ -154,8 +154,7 @@ values={[
 ```rust
 use bevy_rapier2d::prelude::*;
 
-commands.spawn()
-    .insert(Collider::cuboid(1.0, 2.0))
+commands.spawn(Collider::cuboid(1.0, 2.0))
     .insert(Sensor)
     .insert_bundle(TransformBundle::from(Transform::from_xyz(2.0, 0.0, 0.0)))
     .insert(Friction::coefficient(0.7))
@@ -169,8 +168,7 @@ commands.spawn()
 ```rust
 use bevy_rapier3d::prelude::*;
 
-commands.spawn()
-    .insert(Collider::cuboid(1.0, 2.0, 3.0))
+commands.spawn(Collider::cuboid(1.0, 2.0, 3.0))
     .insert(Sensor)
     .insert_bundle(TransformBundle::from(Transform::from_xyz(2.0, 0.0, 0.0)))
     .insert(Friction::coefficient(0.7))
@@ -193,20 +191,16 @@ way allows you to attach multiple colliders to the same rigid-body:
 
 ```rust
 // Attach a single collider to a rigid-body.
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(Collider::ball(0.5));
 
 // Attach a multiple colliders to a rigid-body.
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .with_children(|children| {
-        children.spawn()
-            .insert(Collider::ball(0.5))
+        children.spawn(Collider::ball(0.5))
             // Position the collider relative to the rigid-body.
             .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 0.0, -1.0)));
-        children.spawn()
-            .insert(Collider::ball(0.5))
+        children.spawn(Collider::ball(0.5))
             // Position the collider relative to the rigid-body.
             .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 0.0, 1.0)));
     });

--- a/docs/user_guides/templates/collider_friction.mdx
+++ b/docs/user_guides/templates/collider_friction.mdx
@@ -63,8 +63,7 @@ assert_eq!(collider.friction_combine_rule(), CoefficientCombineRule::Min);
 ```rust
 /* Set the friction coefficient and friction combine rule
    when the collider is created. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(Friction {
         coefficient: 0.7,
         combine_rule: CoefficientCombineRule::Min,

--- a/docs/user_guides/templates/collider_mass_properties.mdx
+++ b/docs/user_guides/templates/collider_mass_properties.mdx
@@ -89,7 +89,6 @@ values={[
 <TabItem value="2D">
 
 ```rust
-let rigid_body = RigidBodyBundle::default();
 // First option: by setting the density of the collider (or we could just leave
 //               its default value 1.0).
 let collider_mprops = ColliderMassProperties::Density(2.0);
@@ -112,7 +111,6 @@ commands.spawn(RigidBody::Dynamic)
   <TabItem value="3D">
 
 ```rust
-let rigid_body = RigidBodyBundle::default();
 // First option: by setting the density of the collider (or we could just leave
 //               its default value 1.0).
 let collider_mprops = ColliderMassProperties::Density(2.0);

--- a/docs/user_guides/templates/collider_position.mdx
+++ b/docs/user_guides/templates/collider_position.mdx
@@ -86,8 +86,7 @@ values={[
 
 ```rust
 /* Set the collider position when the collider is created. */
-commands.spawn()
-    .insert(Collider::cuboid(0.5, 0.5))
+commands.spawn(Collider::cuboid(0.5, 0.5))
     .insert_bundle(TransformBundle::from(Transform::from_xyz(1.0, 2.0, 0.0));
 ```
 ```rust
@@ -104,8 +103,7 @@ fn modify_collider_position(mut positions: Query<&mut Transform, With<Collider>)
 
 ```rust
 /* Set the collider position when the collider is created. */
-commands.spawn()
-    .insert(Collider::cuboid(0.5, 0.5, 0.5))
+commands.spawn(Collider::cuboid(0.5, 0.5, 0.5))
     .insert_bundle(TransformBundle::from(Transform::from_xyz(1.0, 2.0, 3.0)));
 ```
 ```rust
@@ -247,11 +245,9 @@ values={[
 // Attach the collider to the rigid-body. The collider is attached as its
 // children, so the collider’s `Transform` components sets its position
 // relative to the parent rigid-body.
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .with_children(|children| {
-        children.spawn()
-            .insert(Collider::cuboid(0.5, 0.5))
+        children.spawn(Collider::cuboid(0.5, 0.5))
             .insert_bundle(TransformBundle::from(Transform::from_xyz(1.0, 2.0, 0.0)));
     });
 ```
@@ -263,11 +259,9 @@ commands.spawn()
 // Attach the collider to the rigid-body. The collider is attached as its
 // children, so the collider’s `Transform` components sets its position
 // relative to the parent rigid-body.
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .with_children(|children| {
-        children.spawn()
-            .insert(Collider::cuboid(0.5, 0.5, 0.5))
+        children.spawn(Collider::cuboid(0.5, 0.5, 0.5))
             .insert_bundle(TransformBundle(Transform::from_xyz(1.0, 2.0, 3.0)));
     });
 ```

--- a/docs/user_guides/templates/collider_restitution.mdx
+++ b/docs/user_guides/templates/collider_restitution.mdx
@@ -63,8 +63,7 @@ assert_eq!(collider.restitution_combine_rule(), CoefficientCombineRule::Min);
 ```rust
 /* Set the restitution coefficient and restitution combine rule
    when the collider is created. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(Restitution {
         coefficient: 0.7,
         combine_rule: CoefficientCombineRule::Min,

--- a/docs/user_guides/templates/collider_type.mdx
+++ b/docs/user_guides/templates/collider_type.mdx
@@ -32,8 +32,7 @@ assert!(collider.is_sensor());
 
 ```rust
 /* Set the collider sensor when the collider is created. */
-commands.spawn()
-    .insert(Collider::ball(0.5))
+commands.spawn(Collider::ball(0.5))
     .insert(Sensor);
 ```
 ```rust

--- a/docs/user_guides/templates/colliders.mdx
+++ b/docs/user_guides/templates/colliders.mdx
@@ -137,8 +137,7 @@ ColliderBuilder::compound(vec![(pos1, shape1), (pos2, shape2)])
 <bevy>
 
 ```rust
-commands.spawn()
-    .insert(Collider::compound(vec![(pos1, rot1, shape1), (pos2, rot2, shape2)]));
+commands.spawn(Collider::compound(vec![(pos1, rot1, shape1), (pos2, rot2, shape2)]));
 ```
 
 </bevy>

--- a/docs/user_guides/templates/getting_started_bevy.mdx
+++ b/docs/user_guides/templates/getting_started_bevy.mdx
@@ -135,14 +135,12 @@ fn setup_graphics(mut commands: Commands) {
 fn setup_physics(mut commands: Commands) {
     /* Create the ground. */
     commands
-        .spawn()
-        .insert(Collider::cuboid(500.0, 50.0))
+        .spawn(Collider::cuboid(500.0, 50.0))
         .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, -100.0, 0.0)));
 
     /* Create the bouncing ball. */
     commands
-        .spawn()
-        .insert(RigidBody::Dynamic)
+        .spawn(RigidBody::Dynamic)
         .insert(Collider::ball(50.0))
         .insert(Restitution::coefficient(0.7))
         .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 400.0, 0.0)));
@@ -184,14 +182,12 @@ fn setup_graphics(mut commands: Commands) {
 fn setup_physics(mut commands: Commands) {
     /* Create the ground. */
     commands
-        .spawn()
-        .insert(Collider::cuboid(100.0, 0.1, 100.0))
+        .spawn(Collider::cuboid(100.0, 0.1, 100.0))
         .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, -2.0, 0.0)));
 
     /* Create the bouncing ball. */
     commands
-        .spawn()
-        .insert(RigidBody::Dynamic)
+        .spawn(RigidBody::Dynamic)
         .insert(Collider::ball(0.5))
         .insert(Restitution::coefficient(0.7))
         .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 4.0, 0.0)));

--- a/docs/user_guides/templates/getting_started_bevy.mdx
+++ b/docs/user_guides/templates/getting_started_bevy.mdx
@@ -14,7 +14,7 @@ of components, systems, and resources that share a common objective.
 The [**bevy_rapier2d**](https://crates.io/crates/bevy_rapier2d) and [**bevy_rapier3d**](https://crates.io/crates/bevy_rapier3d)
 crates which integrate **Rapier** to **Bevy** using their plugin system.
 To get the best of **bevy-rapier** multiple features can be enabled optionally:
-- `debug-render`: enables the debug-renderer plugin.
+- `debug-render-2d`/`debug-render-3d`: enables the debug-renderer plugin.
 - `simd-stable`: enables explicit SIMD optimizations using the [`wide` crate](https://crates.io/crates/wide).
   Has limited cross-platform support but can be used with a stable version of the Rust compiler.
 - `simd-nightly`: enables explicit SIMD optimizations using the [`packed_simd` crate](https://crates.io/crates/packed_simd).
@@ -76,7 +76,7 @@ values={[
 [dependencies]
 # TODO: Replace the * by the latest version numbers.
 bevy = "*"
-bevy_rapier2d = { version = "*", features = [ "simd-stable", "debug-render" ] }
+bevy_rapier2d = { version = "*", features = [ "simd-stable", "debug-render-2d" ] }
 ```
 
   </TabItem>
@@ -86,7 +86,7 @@ bevy_rapier2d = { version = "*", features = [ "simd-stable", "debug-render" ] }
 [dependencies]
 # TODO: Replace the * by the latest version numbers.
 bevy = "*"
-bevy_rapier3d = { version = "*", features = [ "simd-stable", "debug-render" ] }
+bevy_rapier3d = { version = "*", features = [ "simd-stable", "debug-render-3d" ] }
 ```
 
   </TabItem>
@@ -205,10 +205,10 @@ fn print_ball_altitude(positions: Query<&Transform, With<RigidBody>>) {
 
 
 ## The debug renderer
-The `bevy_rapier` plugin comes with a debug-render to help visualize exactly what the physics-engine sees. This
+The `bevy_rapier` plugin comes with a debug-render (either `debug-render-2d` or `debug-render-3d`) to help visualize exactly what the physics-engine sees. This
 can help fixing some bugs like colliders not being properly aligned with your graphics representation.
 The debug-renderer is be enabled by:
-1. Enabling the `debug-render` cargo feature of bevy-rapier.
+1. Enabling the `debug-render-2d` or `debug-render-3d` cargo feature of bevy-rapier.
 2. Adding the plugin `RapierDebugRenderPlugin` to the Bevy app.
 
 ![debug-render](/img/rapier_debug_render.png)

--- a/docs/user_guides/templates/joints.mdx
+++ b/docs/user_guides/templates/joints.mdx
@@ -104,8 +104,7 @@ values={[
 
 ```rust
 let joint = FixedJointBuilder::new().local_anchor(Vec2::new(0.0, -2.0));
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -114,8 +113,7 @@ commands.spawn()
 
 ```rust
 let joint = FixedJointBuilder::new().local_anchor(Vec3::new(0.0, 0.0, -2.0));
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -180,8 +178,7 @@ joint_set.insert(&mut rigid_body_set, body_handle1, body_handle2, joint, true);
 let joint = SphericalJointBuilder::new()
     .local_anchor1(Vec3::new(0.0, 0.0, 1.0))
     .local_anchor2(Vec3::new(0.0, 0.0, -3.0));
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -254,8 +251,7 @@ values={[
 let joint = RevoluteJointBuilder::new()
     .local_anchor1(Vec2::new(0.0, 1.0))
     .local_anchor2(Vec2::new(0.0, -3.0));
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -267,8 +263,7 @@ let x = Vector::x_axis();
 let joint = RevoluteJointBuilder::new(x)
     .local_anchor1(Vec3::new(0.0, 0.0, 1.0))
     .local_anchor2(Vec3::new(0.0, 0.0, -3.0));
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -369,8 +364,7 @@ let mut joint = PrismaticJointBuilder::new(Vec2::X)
     .local_anchor1(Vec2::new(0.0, 1.0))
     .local_anchor2(Vec2::new(0.0, -3.0))
     .limits([-2.0, 5.0]);
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -382,8 +376,7 @@ let mut joint = PrismaticJointBuilder::new(Vec3::X)
     .local_anchor1(Vec3::new(0.0, 0.0, 1.0))
     .local_anchor2(Vec3::new(0.0, 0.0, -3.0))
     .limits([-2.0, 5.0]);
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -506,8 +499,7 @@ let mut joint = PrismaticJointBuilder::new(Vec2::X)
     .local_anchor1(Vec2::new(0.0, 1.0))
     .local_anchor2(Vec2::new(0.0, -3.0))
     .motor_velocity(1.0, 0.5);
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 
@@ -519,8 +511,7 @@ let mut joint = PrismaticJointBuilder::new(Vec3::X)
     .local_anchor1(Vec3::new(0.0, 0.0, 1.0))
     .local_anchor2(Vec3::new(0.0, 0.0, -3.0))
     .motor_velocity(1.0, 0.5);
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ImpulseJoint::new(parent_entity, joint);
 ```
 

--- a/docs/user_guides/templates/rigid_body_ccd.mdx
+++ b/docs/user_guides/templates/rigid_body_ccd.mdx
@@ -39,8 +39,7 @@ assert_eq!(rigid_body.is_ccd_enabled(), true);
 
 ```rust
 /* Enable CCD when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(Ccd::enabled());
 ```
 ```rust

--- a/docs/user_guides/templates/rigid_body_creation_and_insertion.mdx
+++ b/docs/user_guides/templates/rigid_body_creation_and_insertion.mdx
@@ -154,8 +154,7 @@ values={[
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
-commands.spawn()
-        .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
         .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)))
         .insert(Velocity {
             linvel: Vec2::new(1.0, 2.0),
@@ -173,8 +172,7 @@ commands.spawn()
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
-commands.spawn()
-        .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
         .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)))
         .insert(Velocity {
             linvel: Vec3::new(1.0, 2.0, 3.0),

--- a/docs/user_guides/templates/rigid_body_damping.mdx
+++ b/docs/user_guides/templates/rigid_body_damping.mdx
@@ -32,8 +32,7 @@ assert_eq!(rigid_body.angular_damping(), 1.0);
 
 ```rust
 /* Set damping when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(Damping { linear_damping: 0.5, angular_damping: 1.0 });
 ```
 ```rust

--- a/docs/user_guides/templates/rigid_body_dominance.mdx
+++ b/docs/user_guides/templates/rigid_body_dominance.mdx
@@ -43,8 +43,7 @@ assert_eq!(rigid_body.dominance_group(), 10);
 
 ```rust
 /* Set dominance when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(Dominance::group(10));
 ```
 ```rust

--- a/docs/user_guides/templates/rigid_body_forces_and_impulses.mdx
+++ b/docs/user_guides/templates/rigid_body_forces_and_impulses.mdx
@@ -72,8 +72,7 @@ values={[
 
 ```rust
 /* Apply forces when the rigid-body is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ExternalForce {
         force: Vec2::new(1000.0, 2000.0),
         torque: 140.0,
@@ -105,8 +104,7 @@ fn apply_forces(mut ext_forces: Query<&mut ExternalForce>, mut ext_impulses: Que
 
 ```rust
 /* Apply forces when the rigid-body is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(ExternalForce {
         force: Vec3::new(10.0, 20.0, 30.0),
         torque: Vec3::new(1.0, 2.0, 3.0),

--- a/docs/user_guides/templates/rigid_body_gravity.mdx
+++ b/docs/user_guides/templates/rigid_body_gravity.mdx
@@ -47,8 +47,7 @@ assert_eq!(rigid_body.gravity_scale(), 0.5);
 
 ```rust
 /* Set the gravity scale when the rigid-body is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(GravityScale(2.0));
 ```
 ```rust

--- a/docs/user_guides/templates/rigid_body_locking_translations_rotations.mdx
+++ b/docs/user_guides/templates/rigid_body_locking_translations_rotations.mdx
@@ -72,8 +72,7 @@ values={[
 
 ```rust
 /* Lock translations and/or rotations when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(LockedAxes::TRANSLATION_LOCKED);
 ```
 ```rust
@@ -90,8 +89,7 @@ fn modify_body_locked_flags(mut locked_axes: Query<&mut LockedAxes>) {
 
 ```rust
 /* Lock translations and/or rotations when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(LockedAxes::TRANSLATION_LOCKED | LockedAxes::ROTATION_LOCKED_X);
 ```
 ```rust

--- a/docs/user_guides/templates/rigid_body_mass_properties.mdx
+++ b/docs/user_guides/templates/rigid_body_mass_properties.mdx
@@ -39,8 +39,7 @@ collider_set.insert_with_parent(collider, rigid_body_handle, &mut rigid_body_set
 ```rust
 // When the collider is attached, the rigid-body's mass and angular
 // inertia will be automatically updated to take the collider into account.
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(Collider::ball(1.0))
     // The default density is 1.0, we are setting 2.0 for this example.
     .insert(ColliderMassProperties::Density(2.0));
@@ -126,8 +125,7 @@ rigid_body.set_mass_properties(
 
 ```rust
 /* Set the additional mass properties when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(AdditionalMassProperties::Mass(10.0));
 ```
 ```rust

--- a/docs/user_guides/templates/rigid_body_position.mdx
+++ b/docs/user_guides/templates/rigid_body_position.mdx
@@ -103,8 +103,7 @@ values={[
 
 ```rust
 /* Set the position when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)));
 ```
 ```rust
@@ -123,8 +122,7 @@ fn modify_body_translation(mut positions: Query<&mut Transform, With<RigidBody>>
 /* Set the position when the rigid-body bundle is created. */
 ```rust
 /* Set the position when the rigid-body bundle is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert_bundle(TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)));
 ```
 ```rust

--- a/docs/user_guides/templates/rigid_body_velocity.mdx
+++ b/docs/user_guides/templates/rigid_body_velocity.mdx
@@ -93,8 +93,7 @@ values={[
 
 ```rust
 /* Set the velocities when the rigid-body is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(Velocity {
         linvel: Vec2::new(1.0, 2.0),
         angvel: 0.4,
@@ -116,8 +115,7 @@ fn modify_body_velocity(mut velocities: Query<&mut Velocity>) {
 ```rust
 ```rust
 /* Set the velocities when the rigid-body is created. */
-commands.spawn()
-    .insert(RigidBody::Dynamic)
+commands.spawn(RigidBody::Dynamic)
     .insert(Velocity {
         linvel: Vec3::new(1.0, 2.0, 3.0),
         angvel: Vec3::new(0.2, 0.4, 0.8),


### PR DESCRIPTION
The `debug-render` cargo feature was split into two separate features: `debug-render-2d` and `debug-render-3d`. This PR updates the Getting Started doc to match the new features.