### PR TITLE
Update advanced_collision_detection.mdx

### DIFF
--- a/docs/user_guides/templates/advanced_collision_detection.mdx
+++ b/docs/user_guides/templates/advanced_collision_detection.mdx
@@ -592,7 +592,7 @@ fn main() {
 
 struct MyPhysicsHooks;
 
-impl PhysicsHooksWithQuery<NoUserData for MyPhysicsHooks {
+impl PhysicsHooksWithQuery<NoUserData> for MyPhysicsHooks {
     fn modify_solver_contacts(
         &self, 
         context: ContactModificationContextView,


### PR DESCRIPTION
Add missing closing angled brace in Advanced Collision Detection example.