### PR TITLE
Fix: broken QueryPipeline link

### DIFF
--- a/docs/user_guides/templates/scene_queries.mdx
+++ b/docs/user_guides/templates/scene_queries.mdx
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 Scene queries are geometric queries that take all the colliders of the physics world into account. These queries are
-available through the <rapier>[QueryPipeline](simulation_structures#the-query-pipeline)</rapier><bevy>`RapierContext` resource</bevy><js>`World` class</js>.
+available through the <rapier>[QueryPipeline](simulation_structures#query-pipeline)</rapier><bevy>`RapierContext` resource</bevy><js>`World` class</js>.
 
 <rapier>
 


### PR DESCRIPTION
Fix the link from scene_queries page to the Query Pipeline subsection of the simulation_structures page