### PR TITLE
Fix rigid_body_position.mdx typo

### DIFF
--- a/docs/user_guides/templates/rigid_body_position.mdx
+++ b/docs/user_guides/templates/rigid_body_position.mdx
@@ -120,8 +120,6 @@ fn modify_body_translation(mut positions: Query<&mut Transform, With<RigidBody>>
 
 ```rust
 /* Set the position when the rigid-body bundle is created. */
-```rust
-/* Set the position when the rigid-body bundle is created. */
 commands.spawn(RigidBody::Dynamic)
     .insert(TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)));
 ```


### PR DESCRIPTION
There's a duplicate code section here.