### PR TITLE
Updated deprecated function in example

### DIFF
--- a/docs/user_guides/templates/advanced_collision_detection.mdx
+++ b/docs/user_guides/templates/advanced_collision_detection.mdx
@@ -103,11 +103,11 @@ fn display_events(
     mut collision_events: EventReader<CollisionEvent>,
     mut contact_force_events: EventReader<ContactForceEvent>,
 ) {
-    for collision_event in collision_events.iter() {
+    for collision_event in collision_events.read() {
         println!("Received collision event: {:?}", collision_event);
     }
 
-    for contact_force_event in contact_force_events.iter() {
+    for contact_force_event in contact_force_events.read() {
         println!("Received contact force event: {:?}", contact_force_event);
     }
 }


### PR DESCRIPTION
The .iter() function is deprecated and replaced by .read()