### PR TITLE
Update rigid_body_position.mdx

### DIFF
--- a/docs/user_guides/templates/rigid_body_position.mdx
+++ b/docs/user_guides/templates/rigid_body_position.mdx
@@ -199,7 +199,6 @@ bodies, it is recommended to either set its [velocity](#velocity) or to apply [f
 
 For **velocity-based** kinematic bodies, it is recommended to set its velocity instead of setting its position directly.
 For **position-based** kinematic bodies, it is recommended to use the special methods:
-- `RigidBody::set_next_kinematic_position`
 - `RigidBody::set_next_kinematic_rotation`
 - `RigidBody::set_next_kinematic_translation`
 
@@ -220,7 +219,6 @@ realistic intersections with other rigid-bodies.
 
 For **velocity-based** kinematic bodies, it is recommended to set its velocity instead of setting its position directly.
 For **position-based** kinematic bodies, it is recommended to use the special methods:
-- `RigidBody.setNextKinematicPosition`
 - `RigidBody.setNextKinematicRotation`
 - `RigidBody.setNextKinematicTranslation`
 


### PR DESCRIPTION
Remove `RigidBody.setNextKinematicPosition` from tutorial, because there's no such method in JavaScript API.

![image](https://github.com/dimforge/rapier.rs/assets/2557494/e99e3934-e523-473e-af2f-2420e7d2f2cd)
