### PR TITLE
Fix query filter and closing delimiters in Bevy ray casting docs

### DIFF
--- a/docs/user_guides/templates/scene_queries_ray_casting.mdx
+++ b/docs/user_guides/templates/scene_queries_ray_casting.mdx
@@ -159,8 +159,8 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
             let hit_normal = intersection.normal;
             println!("Entity {:?} hit at point {} with normal {}", entity, hit_point, hit_normal);
             true // Return `false` instead if we want to stop searching for other hits.
-        });
-    }
+        },
+    );
 }
 ```
 
@@ -174,7 +174,7 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
     let ray_dir = Vec3::new(0.0, 1.0, 0.0);
     let max_toi = 4.0;
     let solid = true;
-    let filter = None;
+    let filter = QueryFilter::default();
 
     if let Some((entity, toi)) = rapier_context.cast_ray(
         ray_pos, ray_dir, max_toi, solid, filter
@@ -204,8 +204,8 @@ fn cast_ray(rapier_context: Res<RapierContext>) {
             let hit_normal = intersection.normal;
             println!("Entity {:?} hit at point {} with normal {}", entity, hit_point, hit_normal);
             true // Return `false` instead if we want to stop searching for other hits.
-        });
-    }
+        },
+    );
 }
 ```
 


### PR DESCRIPTION
# Objective

The docs have code examples where `None` is given as a filter instead of a `QueryFilter` and there are extra closing delimiters. This doesn't compile.

## Solution

Fix the docs.