### PR TITLE
Fixed grammatical mistake in collider_creation_and_insertion.mdx

### DIFF
--- a/docs/user_guides/templates/collider_creation_and_insertion.mdx
+++ b/docs/user_guides/templates/collider_creation_and_insertion.mdx
@@ -78,7 +78,7 @@ rigid-body being affected by collisions. The collider's position will be automat
 of the rigid-body it is attached to. There are two ways of attaching a collider to a rigid-body. The second
 way allows you to attach multiple colliders to the same rigid-body:
 1. Attach the `Collider` to the same entity as the `RigidBody`.
-2. Attach the `Collider` to an entity that is a children of the entity containing the `RigidBody`.
+2. Attach the `Collider` to an entity that is a child of the entity containing the `RigidBody`.
 
 ```rust
 <load path='/2d/bevy/examples/colliders2.rs' marker='Creation2' />


### PR DESCRIPTION
Changed line:
Attach the `Collider` to an entity that is a *children* of the entity containing the RigidBody.
to:
Attach the `Collider` to an entity that is a *child* of the entity containing the RigidBody.