### PR TITLE
update docusaurus to 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Website
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
 ### Installation
 

--- a/community/support.mdx
+++ b/community/support.mdx
@@ -26,7 +26,7 @@ it. Do not hesitate to correct even the smallest, insignificant detail
 (especially English mistakes, including typography). We love nitpicking!  This
 website is composed of a set of markdown files located on the
 [rapier.rs](https://github.com/dimforge/rapier.rs) repository. It is compiled using
-[Docusaurus 2](https://v2.docusaurus.io). As explained in the next section,
+[Docusaurus 3](https://docusaurus.io). As explained in the next section,
 you need to fork, fix, and create a pull request targeting the **master**
 branch of the **rapier.rs** repository to make your contribution ready
 to integrate into our code base. There are no specific rules, except that all

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "node": ">=18.0"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.0",
-    "@docusaurus/preset-classic": "^3.0",
+    "@docusaurus/core": "^3.5.2",
+    "@docusaurus/preset-classic": "^3.5.2",
     "@mdx-js/react": "^3.0",
     "clsx": "^1.1.1",
     "react": "^18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,7 +1722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.5.2, @docusaurus/core@npm:^3.0":
+"@docusaurus/core@npm:3.5.2, @docusaurus/core@npm:^3.5.2":
   version: 3.5.2
   resolution: "@docusaurus/core@npm:3.5.2"
   dependencies:
@@ -2039,7 +2039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:^3.0":
+"@docusaurus/preset-classic@npm:^3.5.2":
   version: 3.5.2
   resolution: "@docusaurus/preset-classic@npm:3.5.2"
   dependencies:
@@ -9649,8 +9649,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rapier@workspace:."
   dependencies:
-    "@docusaurus/core": "npm:^3.0"
-    "@docusaurus/preset-classic": "npm:^3.0"
+    "@docusaurus/core": "npm:^3.5.2"
+    "@docusaurus/preset-classic": "npm:^3.5.2"
     "@mdx-js/react": "npm:^3.0"
     clsx: "npm:^1.1.1"
     react: "npm:^18.2"


### PR DESCRIPTION
- improves https://github.com/dimforge/rapier.rs/issues/41

before this PR, it's easy to find ourselves in a situation where broken links appear a lot, a simple refresh adds a trailing slash, resulting in broken behaviour.

With docusaurus 3.5 ; trailing slashes don´t appear as much, resulting in a better experience.

The underlying issue still exist though, but is difficult to track.