### PR TITLE
docs: fix folder name

### DIFF
--- a/docs/user_guides/templates/getting_started_js.mdx
+++ b/docs/user_guides/templates/getting_started_js.mdx
@@ -64,7 +64,7 @@ example with a dynamic rigid-body falling on the ground.
   </TabItem>
 </Tabs>
 
-See the `testbed3d/src/demos` and `testbed2d/src/demos` folders for examples on how to initialize a Rapier physics
+See the `examples2d` and `examples3d` folders for examples on how to initialize a Rapier physics
 world using these bindings.
 
 ## Using Rapier without a bundler


### PR DESCRIPTION
Update the location of examples