### PR TITLE
Update snap to ground documentation to match implementation

### DIFF
--- a/docs/user_guides/templates/character_controller_snap_to_ground.mdx
+++ b/docs/user_guides/templates/character_controller_snap_to_ground.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 If enabled, **snap-to-ground** will force the character to stick to the ground if the following conditions are met
 simultaneously:
 - At the start of the movement, the character touches the ground.
-- The movement has no up component (i.e. the character isn’t jumping).
+- The movement has a slight downward component.
 - At the end of the desired movement, the character would be separated from the ground by a distance smaller than the
 distance provided by the **snap-to-ground** parameter.
 


### PR DESCRIPTION
I'm writing a game that makes use of rapier, and I was scratching my head for quite a while trying to figure out why snap to ground wasn't working. Turned out to be because of [this line of code](https://github.com/dimforge/rapier/blob/3855592447b01ee80240f882c8edc140b2d8e18d/src/control/character_controller.rs#L402). Whereas the docs say that snapping to ground requires no up component, the implementation actually requires it to be less than `-1e-5`. I had been setting it to 0 when grounded, thus the confusion.