### PR TITLE
Refactor vector usage to use Vec2 type

### DIFF
--- a/docs-examples/2d/rust/examples/rs_basic_sim2.rs
+++ b/docs-examples/2d/rust/examples/rs_basic_sim2.rs
@@ -11,14 +11,14 @@ fn main() {
 
     /* Create the bouncing ball. */
     let rigid_body = RigidBodyBuilder::dynamic()
-        .translation(vector![0.0, 10.0])
+        .translation(Vec2::new(0.0, 10.0))
         .build();
     let collider = ColliderBuilder::ball(0.5).restitution(0.7).build();
     let ball_body_handle = rigid_body_set.insert(rigid_body);
     collider_set.insert_with_parent(collider, ball_body_handle, &mut rigid_body_set);
 
     /* Create other structures necessary for the simulation. */
-    let gravity = vector![0.0, -9.81];
+    let gravity = Vec2::new(0.0, -9.81);
     let integration_parameters = IntegrationParameters::default();
     let mut physics_pipeline = PhysicsPipeline::new();
     let mut island_manager = IslandManager::new();
@@ -33,7 +33,7 @@ fn main() {
     /* Run the game loop, stepping the simulation once per frame. */
     for _ in 0..200 {
         physics_pipeline.step(
-            &gravity,
+            gravity,
             &integration_parameters,
             &mut island_manager,
             &mut broad_phase,


### PR DESCRIPTION
rapier2d 0.32 migrated its internal vector type from nalgebra to glam.
The getting-started example uses `vector![]` which produces a nalgebra
Matrix type, causing two compile errors on the translation call:

  error[E0308]: mismatched types
  expected struct `Vec2`
  found struct `Matrix<{float}, Const<2>, Const<1>, ArrayStorage<{float}, 2, 1>>`

Additionally, gravity is passed as `&gravity` (by reference) to
`physics_pipeline.step()`, which also fails since the method now
expects `Vec2` by value, not a reference to a nalgebra Matrix:

  error[E0308]: mismatched types
  expected struct `Vec2`
  found reference `&Matrix<{float}, Const<2>, Const<1>, ArrayStorage<{float}, 2, 1>>`

Fix: replace all `vector![]` usages with `Vec2::new()` and pass
gravity by value instead of by reference.